### PR TITLE
Prepare make clean to replace clean.sh

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -142,7 +142,7 @@ endif
 
 clean: CLEAN_RULE_HOOK
 	@echo Cleaning
-	-rm -fR .dep $(BUILDDIR)
+	-rm -fR .dep $(BUILDDIR) pch/pch.h.gch
 	@echo Done
 
 CLEAN_RULE_HOOK:


### PR DESCRIPTION
clean.sh deletes something that `make clean` doesn't, let's fix that so we can get rid of clean.sh