### PR TITLE
copyArrayInterpolated

### DIFF
--- a/util/test/test_arrays.cpp
+++ b/util/test/test_arrays.cpp
@@ -42,3 +42,91 @@ TEST(Util_Arrays, Size) {
 	ASSERT_EQ(17u, efi::size(arr2));
 	ASSERT_EQ(21u, efi::size(arr3));
 }
+
+#define ARRAY_INTERPOLATION_ERROR 0.01f
+
+TEST(Util_Arrays, copyArrayInterpolated){
+	// direct copy
+	{
+		float src[] = { 1.0f, 2.0f, 3.0f };
+		float dest[3];
+		copyArrayInterpolated(dest, src);
+		ASSERT_THAT(dest, ElementsAre(1.0f, 2.0f, 3.0f));
+	}
+
+	// Test upscaling with interpolation (2 -> 5)
+	{
+		float src[] = { 0.0f, 10.0f };
+		float dest[5];
+		copyArrayInterpolated(dest, src);
+		ASSERT_NEAR(dest[0], 0.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[1], 2.5f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[2], 5.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[3], 7.5f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[4], 10.0f, ARRAY_INTERPOLATION_ERROR);
+	}
+
+	// Test upscaling with interpolation (3 -> 7)
+	{
+		float src[] = { 0.0f, 6.0f, 12.0f };
+		float dest[7];
+		copyArrayInterpolated(dest, src);
+		ASSERT_NEAR(dest[0], 0.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[1], 2.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[2], 4.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[3], 6.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[4], 8.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[5], 10.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[6], 12.0f, ARRAY_INTERPOLATION_ERROR);
+	}
+
+	// Test downscaling (5 -> 3)
+	{
+		float src[] = { 0.0f, 2.5f, 5.0f, 7.5f, 10.0f };
+		float dest[3];
+		copyArrayInterpolated(dest, src);
+		ASSERT_THAT(dest, ElementsAre(0.0f, 5.0f, 10.0f));
+	}
+
+	// Test rounding with default (2 digits)
+	{
+		float src[] = { 0.0f, 1.0f };
+		float dest[3];
+		copyArrayInterpolated(dest, src);
+		// Middle value should be 0.5, rounded to 2 digits
+		EXPECT_FLOAT_EQ(dest[0], 0.0f);
+		EXPECT_FLOAT_EQ(dest[1], 0.5f);
+		EXPECT_FLOAT_EQ(dest[2], 1.0f);
+	}
+
+	// Test rounding with 1 digit
+	{
+		float src[] = { 0.0f, 1.0f };
+		float dest[4];
+		copyArrayInterpolated<float, float, 4, 2, 1>(dest, src);
+		EXPECT_FLOAT_EQ(dest[0], 0.0f);
+		EXPECT_NEAR(dest[1], 0.3f, 0.05f);
+		EXPECT_NEAR(dest[2], 0.7f, 0.05f);
+		EXPECT_FLOAT_EQ(dest[3], 1.0f);
+	}
+
+	// Test with integer types
+	{
+		int src[] = { 0, 100 };
+		int dest[5];
+		copyArrayInterpolated(dest, src);
+		ASSERT_THAT(dest, ElementsAre(0, 25, 50, 75, 100));
+	}
+
+	// Test different src/dest types
+	{
+		int src[] = { 0, 10, 20 };
+		float dest[5];
+		copyArrayInterpolated(dest, src);
+		ASSERT_NEAR(dest[0], 0.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[1], 5.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[2], 10.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[3], 15.0f, ARRAY_INTERPOLATION_ERROR);
+		ASSERT_NEAR(dest[4], 20.0f, ARRAY_INTERPOLATION_ERROR);
+	}
+}


### PR DESCRIPTION
I hope this is a better approach to "putting an array of X size to a one of Y size" problem of [#8931](https://github.com/rusefi/rusefi/issues/8931)

template using with another rounding different from 2 digits should be a bit painful 

```c++
copyArrayInterpolated<float, float, 4, 2, 1>(dest, src);
``` 
But by using the argument in the template I can use/abuse of constexpr if's
https://en.cppreference.com/w/cpp/language/if.html#Constexpr_if